### PR TITLE
Transformation for ATLAS stamp

### DIFF
--- a/.github/workflows/build_staging.yml
+++ b/.github/workflows/build_staging.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - fix/mars-upload
+      - fix/atlas-stamp-orientation
 
 jobs:
   get_tags:

--- a/.github/workflows/build_staging.yml
+++ b/.github/workflows/build_staging.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/atlas-stamp-orientation
 
 jobs:
   get_tags:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astropy==5.1
+scipy==1.8.1
 fastavro==1.5.1
 werkzeug==2.0.2
 Flask==2.1.2

--- a/stamp_service/fits2png.py
+++ b/stamp_service/fits2png.py
@@ -40,10 +40,10 @@ def transform(compressed_fits_file, file_type, window):
     ax = fig.add_subplot()
 
     opts = dict(cmap='Greys_r', interpolation="nearest", vmin=vmin, vmax=vmax)
-    try:
+    try:  # Transformation required to properly orient ATLAS stamps
         data = ndimage.rotate(data, hdu.header['PA'])
         opts['origin'] = 'lower'
-    except KeyError:
+    except KeyError:  # Required for ZTF
         opts['origin'] = 'upper'
     ax.imshow(data, **opts)
 

--- a/stamp_service/fits2png.py
+++ b/stamp_service/fits2png.py
@@ -19,8 +19,7 @@ def _read_compressed_fits(compressed_fits_file):
 def get_max(data, window):
     x = data.shape[0] // 2
     y = data.shape[1] // 2
-    center = data[np.arange(x - window, x + window), :]
-    center = center[:, np.arange(y - window, y + window)]
+    center = data[x - window:x + window, y - window:y + window]
     max_val = np.max(center)
     min_val = np.min(data) + 0.2 * np.median(np.abs(data - np.median(data)))
 

--- a/stamp_service/fits2png.py
+++ b/stamp_service/fits2png.py
@@ -31,8 +31,8 @@ def transform(compressed_fits_file, file_type, window):
     hdu = _read_compressed_fits(compressed_fits_file)
 
     data = hdu.data
-    is_diff = file_type != "difference"
-    vmax, vmin = get_max(data, window) if is_diff else (data.max(), data.min())
+    vmax, vmin = (get_max(data, window)
+                  if file_type != "difference" else (data.max(), data.min()))
 
     buf = io.BytesIO()
 

--- a/tests/unittest/test_fits2png.py
+++ b/tests/unittest/test_fits2png.py
@@ -28,7 +28,6 @@ class TestGetMaxValueRange(unittest.TestCase):
         self.assertEqual(expected, vmin)
 
 
-@mock.patch('stamp_service.fits2png.ndimage')
 @mock.patch('stamp_service.fits2png.plt')
 @mock.patch('stamp_service.fits2png.get_max')
 class TestFITS2PNGTransform(unittest.TestCase):
@@ -38,9 +37,10 @@ class TestFITS2PNGTransform(unittest.TestCase):
 
     @mock.patch('stamp_service.fits2png.fio')
     @mock.patch('stamp_service.fits2png.gzip')
-    def test_opening_of_gzipped_fits(self, mock_gzip, mock_fio, mock_max, mock_plt, mock_ndimage):
+    def test_opening_of_gzipped_fits(self, mock_gzip, mock_fio, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_fio.open.return_value[0].data = self.data
+        mock_fio.open.return_value[0].header = {}
 
         fits2png.transform(b'', '', 2)
         mock_fio.open.assert_called()
@@ -48,9 +48,10 @@ class TestFITS2PNGTransform(unittest.TestCase):
 
     @mock.patch('stamp_service.fits2png.fio')
     @mock.patch('stamp_service.fits2png.gzip')
-    def test_opening_of_not_gzipped_fits(self, mock_gzip, mock_fio, mock_max, mock_plt, mock_ndimage):
+    def test_opening_of_not_gzipped_fits(self, mock_gzip, mock_fio, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_fio.open.return_value[0].data = self.data
+        mock_fio.open.return_value[0].header = {}
         mock_gzip.side_effect = IOError()
 
         fits2png.transform(b'', '', 2)
@@ -58,32 +59,36 @@ class TestFITS2PNGTransform(unittest.TestCase):
         mock_gzip.open.assert_called()
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_when_using_difference_stamp_do_not_change_min_max(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_when_using_difference_stamp_do_not_change_min_max(self, mock_read, mock_max, mock_plt):
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', 'difference', 2)
         mock_max.assert_not_called()
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_when_using_stamp_not_difference_change_min_max(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_when_using_stamp_not_difference_change_min_max(self, mock_read, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', '', 2)
         mock_max.assert_called()
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_pyplot_removes_axis_from_figure(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_pyplot_removes_axis_from_figure(self, mock_read, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', '', 2)
         mock_plt.figure.return_value.add_subplot.return_value.axis.assert_called_with('off')
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_pyplot_saves_image_as_png_in_bytes_buffer(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_pyplot_saves_image_as_png_in_bytes_buffer(self, mock_read, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', '', 2)
         args = mock_plt.figure.return_value.savefig.call_args
@@ -91,26 +96,29 @@ class TestFITS2PNGTransform(unittest.TestCase):
         self.assertEqual('png', args.kwargs['format'])
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_figure_is_closed(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_figure_is_closed(self, mock_read, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', '', 2)
         mock_plt.close.assert_called()
 
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_output_is_a_bytes_object(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_output_is_a_bytes_object(self, mock_read, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
+        mock_read.return_value.header = {}
 
         out = fits2png.transform(b'', '', 2)
         self.assertEqual(b'', out)
 
+    @mock.patch('stamp_service.fits2png.ndimage')
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_no_rotation_applied_if_pa_not_in_header(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_no_rotation_applied_if_pa_not_in_header(self, mock_read, mock_ndimage, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
-        mock_read.return_value.header = dict()
+        mock_read.return_value.header = {}
 
         fits2png.transform(b'', '', 2)
         mock_ndimage.rotate.assert_not_called()
@@ -118,8 +126,9 @@ class TestFITS2PNGTransform(unittest.TestCase):
         self.assertIn('origin', kwargs)
         self.assertEqual(kwargs['origin'], 'upper')
 
+    @mock.patch('stamp_service.fits2png.ndimage')
     @mock.patch('stamp_service.fits2png._read_compressed_fits')
-    def test_rotation_applied_if_pa_present_in_header(self, mock_read, mock_max, mock_plt, mock_ndimage):
+    def test_rotation_applied_if_pa_present_in_header(self, mock_read, mock_ndimage, mock_max, mock_plt):
         mock_max.return_value = 1, 0
         mock_read.return_value.data = self.data
         mock_read.return_value.header = dict(PA=0)


### PR DESCRIPTION
Switched plotting method from matshow to imshow.

Atlas stamps are now rotated based on the PA angle and plotted with origin in lower left corner. If such key is not present in fits header, assumes it is from ZTF and origin is set to upper left corner.

This keeps the orientation of the stamps consistent, but note that the FOV is larger for ATLAS than ZTF.