### PR TITLE
Fixed black stamps for ZTF

### DIFF
--- a/stamp_service/filters.py
+++ b/stamp_service/filters.py
@@ -10,10 +10,8 @@ def filter_atlas_data(filter_name, arg_key):
             """
             apply_all = "*" in ralidator.ralidator.user_filters
             if (
-                (apply_all or
-                filter_name in ralidator.ralidator.user_filters)
-                and kwargs[arg_key] == "atlas"
-            ):
+                apply_all or filter_name in ralidator.ralidator.user_filters
+            ) and kwargs[arg_key] == "atlas":
                 return None
             else:
                 return arg_function(*args, **kwargs)

--- a/stamp_service/fits2png.py
+++ b/stamp_service/fits2png.py
@@ -20,8 +20,8 @@ def get_max(data, window):
     x = data.shape[0] // 2
     y = data.shape[1] // 2
     center = data[x - window : x + window, y - window : y + window]
-    max_val = np.max(center)
-    min_val = np.min(data) + 0.2 * np.median(np.abs(data - np.median(data)))
+    max_val = np.nanmax(center)
+    min_val = np.nanmin(data) + 0.2 * np.nanmedian(np.abs(data - np.nanmedian(data)))
 
     return max_val, min_val
 
@@ -31,7 +31,7 @@ def transform(compressed_fits_file, file_type, window):
 
     data = hdu.data
     vmax, vmin = (
-        get_max(data, window) if file_type != "difference" else (data.max(), data.min())
+        get_max(data, window) if file_type != "difference" else (np.nanmax(data), np.nanmin(data))
     )
 
     buf = io.BytesIO()

--- a/stamp_service/fits2png.py
+++ b/stamp_service/fits2png.py
@@ -31,7 +31,9 @@ def transform(compressed_fits_file, file_type, window):
 
     data = hdu.data
     vmax, vmin = (
-        get_max(data, window) if file_type != "difference" else (np.nanmax(data), np.nanmin(data))
+        get_max(data, window)
+        if file_type != "difference"
+        else (np.nanmax(data), np.nanmin(data))
     )
 
     buf = io.BytesIO()

--- a/stamp_service/resources.py
+++ b/stamp_service/resources.py
@@ -75,14 +75,13 @@ api = Api(
 @api.response(200, "Success")
 @api.response(404, "AVRO not found")
 class StampResource(Resource):
-
     @api.expect(stamp_parser, validate=True)
     @set_permissions_decorator(["admin", "basic_user"])
     @check_permissions_decorator
     def get(self):
         args = stamp_parser.parse_args()
         candid = args["candid"]
-        survey_id = args['survey_id']
+        survey_id = args["survey_id"]
         file_type = args["type"]
         format = args["format"]
         oid = args["oid"]
@@ -92,7 +91,7 @@ class StampResource(Resource):
             survey_id=survey_id,
             file_type=file_type,
             format=format,
-            oid=oid
+            oid=oid,
         )
         if stamp_params:
             return send_file(
@@ -120,7 +119,7 @@ class StampResource(Resource):
             }
         except FileNotFoundError:
             app.logger.info(f"[MISS] AVRO {candid} not found in S3.")
-        
+
         if survey_id == "ztf":
             # Search in MARS
             try:
@@ -160,7 +159,6 @@ class StampResource(Resource):
 @api.response(200, "Success")
 @api.response(404, "AVRO not found")
 class GetAVROInfoResource(Resource):
-
     @api.expect(avro_parser)
     @set_permissions_decorator(["admin", "basic_user"])
     @check_permissions_decorator
@@ -170,12 +168,8 @@ class GetAVROInfoResource(Resource):
         survey_id = args["survey_id"]
         oid = args["oid"]
 
-        avro_data = self.get_avro(
-            candid=candid,
-            survey_id=survey_id,
-            oid=oid
-        )
-        
+        avro_data = self.get_avro(candid=candid, survey_id=survey_id, oid=oid)
+
         if avro_data:
             return avro_data
 
@@ -223,7 +217,6 @@ class GetAVROInfoResource(Resource):
 @api.response(200, "Success")
 @api.response(500, "Server error")
 class PutAVROResource(Resource):
-
     @api.expect(upload_parser)
     @set_permissions_decorator(["admin"])
     @check_permissions_decorator
@@ -232,11 +225,15 @@ class PutAVROResource(Resource):
         reverse_candid = utils.reverse_candid(args["candid"])
         file_name = "{}.avro".format(reverse_candid)
         app.logger.info(
-            "Saving on s3://{}/{}".format(s3_searcher.buckets_dict[args['survey_id']]['bucket'], file_name)
+            "Saving on s3://{}/{}".format(
+                s3_searcher.buckets_dict[args["survey_id"]]["bucket"], file_name
+            )
         )
         f = args["avro"]
         try:
-            response = s3_searcher.upload_file(f, object_name=file_name, survey_id=args['survey_id'])
+            response = s3_searcher.upload_file(
+                f, object_name=file_name, survey_id=args["survey_id"]
+            )
             return jsonify(response)
         except Exception as e:
             app.logger.info("Could not upload file to S3")
@@ -248,7 +245,6 @@ class PutAVROResource(Resource):
 @api.response(200, "Success")
 @api.response(404, "AVRO not found")
 class GetAVROResource(Resource):
-
     @api.expect(avro_parser)
     @set_permissions_decorator(["admin", "basic_user"])
     @check_permissions_decorator
@@ -259,11 +255,7 @@ class GetAVROResource(Resource):
         survey_id = args["survey_id"]
         oid = args["oid"]
 
-        avro_params = self.get_avro(
-            candid=candid,
-            survey_id=survey_id,
-            oid=oid
-        )
+        avro_params = self.get_avro(candid=candid, survey_id=survey_id, oid=oid)
         if avro_params:
             return send_file(
                 avro_params["file"],
@@ -271,7 +263,6 @@ class GetAVROResource(Resource):
                 download_name=avro_params["download_name"],
                 as_attachment=avro_params["as_attachment"],
             )
-
 
     @filter_atlas_data(filter_name="filter_atlas_avro", arg_key="survey_id")
     def get_avro(self, candid, survey_id, oid=None):
@@ -306,7 +297,7 @@ class GetAVROResource(Resource):
                 file_name = f"{candid}.avro"
                 return {
                     "file": output,
-                    "mimetype":"app/avro+binary",
+                    "mimetype": "app/avro+binary",
                     "download_name": file_name,
                     "as_attachment": True,
                 }

--- a/tests/unittest/test_fits2png.py
+++ b/tests/unittest/test_fits2png.py
@@ -17,6 +17,17 @@ class TestGetMaxValueRange(unittest.TestCase):
         vmax, _ = fits2png.get_max(data, window)
         self.assertEqual(max_in, vmax)
 
+    def test_get_max_only_gets_maximum_inside_for_off_diagonal_edge(self):
+        xsize, ysize = 10, 10
+        data = np.zeros((xsize, ysize))
+        window = 2
+        max_in, max_out = 1, 5  # Higher outside window
+        data[xsize // 2 + 1, ysize // 2 - 1] = max_in
+        data[0, 0] = max_out
+
+        vmax, _ = fits2png.get_max(data, window)
+        self.assertEqual(max_in, vmax)
+
     def test_get_max_gets_minimum_from_full_data(self):
         xsize, ysize = 10, 10
         np.random.seed(616)


### PR DESCRIPTION
Some stamps in ZTF appear fully black. This only happens with stamps that have masks in them, i.e., there are `nan` values inside the fits.

This makes the maximum/minimum calculations for the image contrast fail as they return `None`.

This has been fixed by usin `np.nanmin`, `np.nanmax` and `np.nanmedian` in order to avoid ending with `nan` limits.